### PR TITLE
setup_ros via parameter command

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ An script automating the installation of ROS, with both ROS1 and ROS2.
 Call it with:
 
 ```shell
-python3 setup_ros.py
+python3 setup_ros.py [feature]
 ```
 
-If you want to tweak what `setup_ros` installs change the variable `features`:
+If you want to tweak what `setup_ros` installs specify it using `feature` parameter via command:
 
 * `ros1`: ROS1 libs, enablement, and `catkin_ws` setup.
 * `ros2`: ROS2 libs, enablement, and `dev_ws` setup.

--- a/setup_ros.py
+++ b/setup_ros.py
@@ -8,14 +8,21 @@ import subprocess
 import sys
 from typing import Any, Dict
 
+
 def output_of(c: str) -> str:
     return subprocess.check_output([c]).strip().decode("utf-8")
+
 
 if output_of("whoami") == "root":
     sys.exit("You are running this program as root, don't do it. Remove 'sudo'.")
 
+
+features = {}
+for i in range(1, len(len(sys.argv))):
+    features.add(sys.argv[i])
+
 # available features: ros1, ros2, nao
-features = {"ros1", "ros2", "nao", "vscode"}
+# features = {"ros1", "ros2", "nao", "vscode"}
 
 ros1_dist_mapping = {
     # Ubuntu


### PR DESCRIPTION
Usage:

`python3 setup_ros.py ros1`
`python3 setup_ros.py ros2`
`python3 setup_ros.py ros1 ros2`
`python3 setup_ros.py ros1 nao`
`python3 setup_ros.py ros1 ros2 nao`

And so on...